### PR TITLE
Fixed stacktrace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,8 +49,17 @@ module.exports = class MochaWrapper extends Mocha {
           const title = line.replace(/^# pass/, '').trim()
           runner.emit('pass', { title, slow: () => 100, duration })
         } else if (/^# fail/.test(line)) {
-          const title = line.replace(/^# fail/, '').trim()
-          runner.emit('fail', { title, fullTitle: () => title, titlePath: () => [title] }, new Error(title))
+          let [title, stacktrace] = line.split('\\\\n')
+
+          title = title.replace(/^# fail/, '').trim()
+          stacktrace = stacktrace.replace(/\\n/g, '\n')
+          let [message] = stacktrace.split('\n')
+          message = message.replace(/^Error: /, '').trim()
+
+          const error = new Error(message)
+          error.stack = stacktrace
+
+          runner.emit('fail', { title, fullTitle: () => title, titlePath: () => [title] }, error)
         } else if (/^# suite/.test(line)) {
           const title = line.replace(/^# suite/, '').trim()
           if (suite) {
@@ -66,10 +75,9 @@ module.exports = class MochaWrapper extends Mocha {
 
     const codes = await map(testFiles, ({ file, options }) => {
       const Mocha = require('mocha')
-      const Promise = require('es6-promise')
       function Reporter (runner) {
         let prevSuite
-        const onTest = test => {
+        const onTest = () => {
           const suite = runner.suite
           const title = suite.title
           if (title !== prevSuite) {
@@ -81,9 +89,9 @@ module.exports = class MochaWrapper extends Mocha {
           onTest(test)
           console.log('# pass ' + test.title.trim())
         })
-        runner.on('fail', test => {
+        runner.on('fail', (test, err) => {
           onTest(test)
-          console.log('# fail ' + test.title.trim())
+          console.log('# fail ' + test.title.trim() + '\\\\n' + err.stack.replace(/\n/g, '\\n'))
         })
       }
       const mocha = new Mocha(Object.assign(options, { reporter: Reporter }))


### PR DESCRIPTION
Example of spec:
```javascript
describe('failing test', function () {
  it('fails', function () {
    throw new Error('failure!')
  })
})
```

Before:
```
failing test

  1) fails


  0 passing (151ms)
  1 failing

  1) fails:
     Error: fails
      at stdout.split.forEach.line (/home/user/mochallel/lib/index.js:75:16)
      at Array.forEach (<anonymous>)
      at processStdout (/home/user/mochallel/lib/index.js:58:28)
      at EventEmitter.onStdout (/home/user/mochallel/node_modules/multiprocess-map/lib/index.js:83:53)
      at EventEmitter.emit (events.js:189:13)
      at Socket.<anonymous> (/home/user/mochallel/node_modules/parallel-worker/lib/async.js:48:9)
      at Socket.emit (events.js:189:13)
      at addChunk (_stream_readable.js:284:12)
      at readableAddChunk (_stream_readable.js:265:11)
      at Socket.Readable.push (_stream_readable.js:220:10)
```

After:
```
failing test

  1) fails


  0 passing (148ms)
  1 failing

  1) fails:
     Error: failure!
      at Context.<anonymous> (test/tests/failing-test/index.js:4:11)
```